### PR TITLE
[PR] Store image src attributes as data-src for content to be expanded

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -204,6 +204,8 @@ while( $timeline_query->have_posts() ) {
 				}
 
 				if ( $show_more ) {
+					// Use a data attribute to avoid loading all images until the extra content is expanded.
+					$content = preg_replace('|<img([^>]*) src="([^"/]*/?[^".]*\.[^"]*)"([^>]*)>|', '<img$1 src="" data-src="$2"$3>', $content);
 					?>
 					<div class="timeline-content-expanded">
 						<?php echo $content; ?>

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -58,6 +58,13 @@ var wsuTimeline = wsuTimeline || {};
 				$target_parent.removeClass('open');
 				$target_parent.find('.timeline-item-read-more').html('More');
 			} else {
+				// Loop through each newly expanded image and assign it's data-src as src.
+				$target_parent.find('.timeline-content-expanded img').each(function(){
+					var $current = $(this);
+					if ( '' === $current.attr('src') ) {
+						$current.attr('src', $current.data('src'));
+					}
+				});
 				$target_parent.addClass('open');
 				$target_parent.find('.timeline-item-read-more').html('Close');
 			}


### PR DESCRIPTION
This allows us to load the image at the last second rather than waiting for everything to load on initial page load.